### PR TITLE
Deprecation warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/cpu_util.ex
+++ b/lib/cpu_util.ex
@@ -81,7 +81,7 @@ defmodule CpuUtil do
   """
   @spec num_cores() :: {:ok, integer()} | :error
   def num_cores do
-    Logger.warn("deprecated. use core_count/0 instead")
+    Logger.warning("deprecated. use core_count/0 instead")
     core_count()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule CpuUtil.MixProject do
     [
       app: :cpu_util,
       version: "0.5.1",
-      elixir: "~> 1.7",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "CpuUtil",


### PR DESCRIPTION
Elixir 1.15 deprecates `Logger.warn` in favor of `Logger.warning`, which was introduced in Elixir 1.11. I figured that I'd fix the `Config` deprecation warning in addition, since that's been around for a lot longer.